### PR TITLE
Use WriteJSON and ReadJSON on Conn struct.

### DIFF
--- a/json.go
+++ b/json.go
@@ -12,7 +12,7 @@ import (
 //
 // See the documentation for encoding/json Marshal for details about the
 // conversion of Go values to JSON.
-func WriteJSON(c *Conn, v interface{}) error {
+func (c *Conn) WriteJSON(v interface{}) error {
 	w, err := c.NextWriter(TextMessage)
 	if err != nil {
 		return err
@@ -30,7 +30,7 @@ func WriteJSON(c *Conn, v interface{}) error {
 //
 // See the documentation for the encoding/json Marshal function for details
 // about the conversion of JSON to a Go value.
-func ReadJSON(c *Conn, v interface{}) error {
+func (c *Conn) ReadJSON(v interface{}) error {
 	_, r, err := c.NextReader()
 	if err != nil {
 		return err

--- a/json.go
+++ b/json.go
@@ -8,6 +8,11 @@ import (
 	"encoding/json"
 )
 
+// DEPRECATED: use c.WriteJSON instead.
+func WriteJSON(c *Conn, v interface{}) error {
+	return c.WriteJSON(v)
+}
+
 // WriteJSON writes the JSON encoding of v to the connection.
 //
 // See the documentation for encoding/json Marshal for details about the
@@ -23,6 +28,11 @@ func (c *Conn) WriteJSON(v interface{}) error {
 		return err1
 	}
 	return err2
+}
+
+// DEPRECATED: use c.WriteJSON instead.
+func ReadJSON(c *Conn, v interface{}) error {
+	return c.ReadJSON(v)
 }
 
 // ReadJSON reads the next JSON-encoded message from the connection and stores

--- a/json_test.go
+++ b/json_test.go
@@ -23,8 +23,16 @@ func TestJSON(t *testing.T) {
 	expect.A = 1
 	expect.B = "hello"
 
+	if err := WriteJSON(wc, &expect); err != nil {
+		t.Fatal("write", err)
+	}
+
 	if err := wc.WriteJSON(&expect); err != nil {
 		t.Fatal("write", err)
+	}
+
+	if err := ReadJSON(rc, &expect); err != nil {
+		t.Fatal("read", err)
 	}
 
 	if err := rc.ReadJSON(&actual); err != nil {

--- a/json_test.go
+++ b/json_test.go
@@ -23,16 +23,8 @@ func TestJSON(t *testing.T) {
 	expect.A = 1
 	expect.B = "hello"
 
-	if err := WriteJSON(wc, &expect); err != nil {
-		t.Fatal("write", err)
-	}
-
 	if err := wc.WriteJSON(&expect); err != nil {
 		t.Fatal("write", err)
-	}
-
-	if err := ReadJSON(rc, &expect); err != nil {
-		t.Fatal("read", err)
 	}
 
 	if err := rc.ReadJSON(&actual); err != nil {
@@ -43,3 +35,30 @@ func TestJSON(t *testing.T) {
 		t.Fatal("equal", actual, expect)
 	}
 }
+
+func TestDeprecatedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	c := fakeNetConn{&buf, &buf}
+	wc := newConn(c, true, 1024, 1024)
+	rc := newConn(c, false, 1024, 1024)
+
+	var actual, expect struct {
+		A int
+		B string
+	}
+	expect.A = 1
+	expect.B = "hello"
+
+	if err := WriteJSON(wc, &expect); err != nil {
+		t.Fatal("write", err)
+	}
+
+	if err := ReadJSON(rc, &actual); err != nil {
+		t.Fatal("read", err)
+	}
+
+	if !reflect.DeepEqual(&actual, &expect) {
+		t.Fatal("equal", actual, expect)
+	}
+}
+

--- a/json_test.go
+++ b/json_test.go
@@ -23,11 +23,11 @@ func TestJSON(t *testing.T) {
 	expect.A = 1
 	expect.B = "hello"
 
-	if err := WriteJSON(wc, &expect); err != nil {
+	if err := wc.WriteJSON(&expect); err != nil {
 		t.Fatal("write", err)
 	}
 
-	if err := ReadJSON(rc, &actual); err != nil {
+	if err := rc.ReadJSON(&actual); err != nil {
 		t.Fatal("read", err)
 	}
 


### PR DESCRIPTION
Created by: tapocol cloned from gorilla/websocket#1

Since it is already a requirement to give the *Conn struct and ReadMessage and WriteMessage were methods on *Conn, figured it made sense to adjust the JSON methods.
