### PR TITLE
Fixes subprotocol selection (aling with rfc6455) fixes #4

### DIFF
--- a/server.go
+++ b/server.go
@@ -101,8 +101,8 @@ func checkSameOrigin(r *http.Request) bool {
 func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {
 	if u.Subprotocols != nil {
 		clientProtocols := Subprotocols(r)
-		for _, serverProtocol := range u.Subprotocols {
-			for _, clientProtocol := range clientProtocols {
+		for _, clientProtocol := range clientProtocols {
+			for _, serverProtocol := range u.Subprotocols {
 				if clientProtocol == serverProtocol {
 					return clientProtocol
 				}


### PR DESCRIPTION
Fixes gorilla/websocket#822 #4 

Original PR: gorilla/websocket#823 by @KSDaemon 

Summary of Changes

    Changed the order of subprotocol selection to prefer client one